### PR TITLE
Remove unnecessary android.permission.WRITE_SETTINGS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,9 +29,6 @@
                 <param name="android-package" value="org.apache.cordova.plugin.Brightness.BrightnessPlugin"/>
             </feature>
         </config-file>
-        <config-file target="AndroidManifest.xml" parent="/*">
-            <uses-permission android:name="android.permission.WRITE_SETTINGS" />
-        </config-file>
 
 	<source-file src="src/android/BrightnessPlugin.java" target-dir="src/org/apache/cordova/plugin/Brightness" />
 


### PR DESCRIPTION
The permission is needed to change the brightness permanently via the System settings. It isn't needed to change the current window brightness as this plugin does.